### PR TITLE
Adds support for midigrid if installed

### DIFF
--- a/torii.lua
+++ b/torii.lua
@@ -61,6 +61,7 @@ local running = true
 local ledlevels = {1,3,5,7,10,15} 
 -- local ledlevels = {15,15,15,15,15,15} -- use this for monobright grids.
 
+local grid = util.file_exists(_path.code.."midigrid") and include "midigrid/lib/mg_128" or grid
 local grds = {}
 local grid_device
 local grid_w = 0


### PR DESCRIPTION
I believe this adds Midigrid support safely so that if the library is not present, torii will fall back to the Monome grid library.
I verified that the script loads and LP Mini MK3 works when midigrid is present, and that the script loads correctly when the midigrid lib is not installed. however, i don't have a Monome Grid to test that it works as expected with this change.